### PR TITLE
修复了一个来自于文本二维码显示的BUG。并修改了Windows下显示二维码的占位字符。

### DIFF
--- a/qqbot/qrcodemanager.py
+++ b/qqbot/qrcodemanager.py
@@ -192,9 +192,9 @@ def showCmdQRCode(filename):
     # currently for Windows, '\u2588' is not correct. So use 'MM' for windows.
     osName = platform.system()
     if osName == 'Windows':
-        white = 'MM'
+        white = '@@'
 
-    blockCount = 2/wcwidth.wcswidth(white)
+    blockCount = int(2/wcwidth.wcswidth(white))
     white *= abs(blockCount)
 
     sys.stdout.write(' '*50 + '\r')


### PR DESCRIPTION
原先执行到 white *= abs(blockCount) 时，由于上一行 blockCount = 2/wcwidth.wcswidth(white) 的除法返回了一个浮点数导致 *= 计算出现异常。通过将返回值强行限制在整数避免出现这个问题。
修改过后的代码显示的二维码的功能工作正常。

新的使用‘@’字符的占位符能够在Windows的默认终端中显示的更好看一些。