### PR TITLE
允许运行多线程访问sqlite3数据库

### DIFF
--- a/qqbot/qcontactdb/contactdb.py
+++ b/qqbot/qcontactdb/contactdb.py
@@ -104,7 +104,7 @@ def tMaker(tinfo):
 
 class ContactDB(object):
     def __init__(self, dbname=':memory:'):
-        self.conn = sqlite3.connect(dbname)
+        self.conn = sqlite3.connect(dbname, check_same_thread=False)
         self.conn.text_factory = str
         self.cursor = self.conn.cursor()
     

--- a/qqbot/qcontactdb/getgroupqq.py
+++ b/qqbot/qcontactdb/getgroupqq.py
@@ -15,7 +15,7 @@ if __name__ == '__main__':
     
     dbname = sys.argv[1]
     outfile = os.path.join(os.path.dirname(dbname), 'groupqq')
-    conn = sqlite3.connect(dbname)
+    conn = sqlite3.connect(dbname, check_same_thread=False)
     conn.text_factory = str
     cursor = conn.cursor()
     cursor.execute("SELECT qq,nick FROM 'group'")


### PR DESCRIPTION
因为poll()有时候太耗时间，所以我尝试用不同的线程处理需要poll()的逻辑和不需要poll()的逻辑。然而写成多线程后会提示以下错误：
sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread.The object was created in thread id 140144062146368 and this is thread id 140143895119616
把
self.conn = sqlite3.connect(dbname)
改为
self.conn = sqlite3.connect(dbname, check_same_thread=False)
即可回避此错误